### PR TITLE
Fixed bold styling in FAQ

### DIFF
--- a/pages/faq.ad
+++ b/pages/faq.ad
@@ -31,7 +31,7 @@ seeing what happens. The Incubator is simply the name of the place
 that governs your actions when you process a new project into
 Apache.  It moves at the same rate you do, and achieves whatever
 you achieve -- the only difference is that we have a permanent
-record in <strong>one</strong> place that we can go back to if
+record in *one* place that we can go back to if
 there are later IP problems, and there is a gate that must be
 passed through before the project is given the right to release
 software on behalf of the ASF.


### PR DESCRIPTION
There was some HTML within the FAQ page which appeared to be intended for making a word bold. This has been replaced with correct Asciidoctor syntax.