### PR TITLE
Fix formatting

### DIFF
--- a/pages/policy/roles_and_responsibilities.ad
+++ b/pages/policy/roles_and_responsibilities.ad
@@ -112,6 +112,7 @@ for the questions and issues likely to be raised by the community.
 
 
 Before incubation begins, the Champion is expected to:
+
 * help with any process/ASF related hurdles before the Candidate enters incubation
 * help find the right people in the ASF to speak with
 * help to find Mentors


### PR DESCRIPTION
The champion section is misformatted: https://incubator.apache.org/policy/roles_and_responsibilities.html#champion

This patch added a newline to fix formatting.