### PR TITLE
INCUBATOR-202 Distribution mirrors section

### DIFF
--- a/pages/guides/transferring.ad
+++ b/pages/guides/transferring.ad
@@ -174,7 +174,9 @@ subscribe to the lists and/or find archives.
 - Distribution mirrors
 ** Dist area (dist.apache.org) *release/${project}* and *dev/${project}* folders can be created by PMC members. 
 *** Do not forget to copy KEYS file from *release/incubator/${project}* location.
-*** Keep incubating released artefacts at *release/incubator/${project}* until your TLP project do their first release.
+*** You have two majors options then:
+**** you can *keep* incubating released artefacts at *release/incubator/${project}* and remove artefacts once your TLP project do their first release.
+**** you can *move* incubating released artefacts to your *release/${project}*, taking care that incubating stay in path (you will need to change website and mail for the new location).
 
 ==== Final Revision of Podling Incubation Records
 

--- a/pages/guides/transferring.ad
+++ b/pages/guides/transferring.ad
@@ -172,7 +172,7 @@ subscribe to the lists and/or find archives.
 ** Ask infra to move the podling to its own top level category in JIRA, if using JIRA
 
 - Distribution mirrors
-** Raise an infra ticket to create your dist area and move your Incubator dist area to the new location.
+** Dist area (dist.apache.org) *release/${project}* and *dev/${project}* folders can be created by PMC members. Do not forget to copy KEYS file from *release/incubator/${project}* location.
 
 ==== Final Revision of Podling Incubation Records
 

--- a/pages/guides/transferring.ad
+++ b/pages/guides/transferring.ad
@@ -172,7 +172,9 @@ subscribe to the lists and/or find archives.
 ** Ask infra to move the podling to its own top level category in JIRA, if using JIRA
 
 - Distribution mirrors
-** Dist area (dist.apache.org) *release/${project}* and *dev/${project}* folders can be created by PMC members. Do not forget to copy KEYS file from *release/incubator/${project}* location.
+** Dist area (dist.apache.org) *release/${project}* and *dev/${project}* folders can be created by PMC members. 
+*** Do not forget to copy KEYS file from *release/incubator/${project}* location.
+*** Keep incubating released artefacts at *release/incubator/${project}* until your TLP project do their first release.
 
 ==== Final Revision of Podling Incubation Records
 

--- a/pages/guides/transferring.ad
+++ b/pages/guides/transferring.ad
@@ -174,8 +174,8 @@ subscribe to the lists and/or find archives.
 - Distribution mirrors
 ** Dist area (dist.apache.org) *release/${project}* and *dev/${project}* folders can be created by PMC members. 
 *** Do not forget to copy KEYS file from *release/incubator/${project}* location.
-*** You have two majors options then:
-**** you can *keep* incubating released artefacts at *release/incubator/${project}* and remove artefacts once your TLP project do their first release.
+*** You have two major options then:
+**** you can *keep* incubating released artefacts at *release/incubator/${project}* and remove artefacts once your TLP project does their first release.
 +
 NOTE: File a JIRA under your newly JIRA *${project}* space to remind to remove */dist/incubator/${project}/* after the first release in */dist/${project}/*
 +

--- a/pages/guides/transferring.ad
+++ b/pages/guides/transferring.ad
@@ -176,7 +176,10 @@ subscribe to the lists and/or find archives.
 *** Do not forget to copy KEYS file from *release/incubator/${project}* location.
 *** You have two majors options then:
 **** you can *keep* incubating released artefacts at *release/incubator/${project}* and remove artefacts once your TLP project do their first release.
-**** you can *move* incubating released artefacts to your *release/${project}*, taking care that incubating stay in path (you will need to change website and mail for the new location).
++
+NOTE: File a JIRA under your newly JIRA *${project}* space to remind to remove */dist/incubator/${project}/* after the first release in */dist/${project}/*
++
+**** you can *move* the last incubating released artefacts to your *release/${project}*, taking care that incubating stay in path (you will need to change website and mail for the new location)
 
 ==== Final Revision of Podling Incubation Records
 


### PR DESCRIPTION
Hi, another quick fix for the guide

It's seems that PMC can do the dist.apache.org settings with no direct need of INFRA (except unexpected issues).

Regards