### PR TITLE
Rework the homepage as discussed in 'overzealous bureaucracy' thread

### DIFF
--- a/pages/index.ad
+++ b/pages/index.ad
@@ -1,4 +1,4 @@
-= Apache Incubator
+= The Apache Incubator
 Apache Incubator PMC
 2002-10-16
 :jbake-type: homepage
@@ -6,32 +6,47 @@ Apache Incubator PMC
 :idprefix:
 :imagesdir: ./images/
 
-The Incubator is the entry path into The Apache Software Foundation (ASF) for projects and codebases wishing to become part of the Foundation's efforts. All code donations from external organisations and existing external projects wishing to join Apache enter through the Incubator.
+The Apache Incubator provides services to projects which want to enter
+the Apache Software Foundation (ASF).
 
-The Apache Incubator has two primary goals:
+It helps those incoming projects (called "podlings") adopt the Apache
+link:http://apache.org/theapacheway/[style of governance and operation]
+and guides them to the ASF services available to our projects so they
+can become top-level ASF projets ("TLPs").
 
-- Ensure all donations are in accordance with the ASF http://www.apache.org/licenses/[legal standards]
-- Develop new communities that adhere to our http://www.apache.org/foundation/how-it-works.html[guiding principles]
+The Incubator delegates a few mentors for each podling, as "on the
+ground" agents to act as liaisons with the various ASF teams:
+link:http://incubator.apache.org[Incubator PMC],
+link:https://selfserve.apache.org/[Infrastructure team] etc.
+and facilitate the podling's growth and operations.
 
-See also the http://www.youtube.com/watch?v=KopPbWS87fw[Life In The Apache Incubator video], where former Incubator PMC chair Jukka Zitting presents the Incubator, at ApacheCon EU 2012.
+Our link:http://incubator.apache.org/cookbook/[cookbook] helps
+potential podlings decide whether the ASF is a good fit for them
+and guides them through the steps required to become an
+ASF podling.
 
-== Getting started at the Apache Incubator
-
-Use the navigation bar at the top of this page to get started:
-
-- Bring your new project *Proposal* to the incubator
-- Review the *Podling Guides* for how podings here work
-- Our *PMC Guides* include information on mentoring, IP clearance, and more
-- All the *Policies* around the Incubator are public
-- Of course we have a https://incubator.apache.org/faq.html[FAQ]!
-
-== Getting in touch with the Incubator
-
-Contact us on the \general@incubator.apache.org mailing list: mailto:general-subscribe@incubator.apache.org[Subscribe] - mailto:general-unsubscribe@incubator.apache.org[Unsubscribe].  You can easily https://s.apache.org/B5Ai[follow discussions on the mailing list archive] using our forum-like interface. 
-
-Or, read our https://incubator.apache.org/guides/lists.html[complete guide for Incubator mailing lists].
+See also the http://www.youtube.com/watch?v=KopPbWS87fw[Life In The Apache Incubator video],
+where former Incubator PMC chair Jukka Zitting presents the Incubator,
+at ApacheCon EU 2012.
 
 == About The Apache Software Foundation
-The Apache Software Foundation provides organizational, legal, and financial support for a broad range of open source software projects. The Foundation provides an established framework for intellectual property and financial contributions that simultaneously limits the potential legal exposure for the contributors. Through a collaborative and meritocratic development process, Apache projects deliver enterprise-grade, freely available software products that attract large communities of users. The pragmatic Apache License makes it easy for all users, commercial and individual, to deploy Apache products.
 
-http://www.apache.org/foundation/[Learn more about the ASF] as a whole, or https://community.apache.org/[engage with the Apache Community Development project] with your general questions about the ASF.
+The Apache Software Foundation provides organizational, legal, and financial support
+for a broad range of open source software projects.
+
+The Foundation provides an established framework for intellectual property and
+financial contributions that simultaneously limits the potential legal exposure
+for the contributors.
+
+Through a collaborative and meritocratic development process known as
+"link:http://apache.org/theapacheway/[the Apache Way]" , Apache projects
+deliver enterprise-grade, freely available software products that attract
+large communities of users.
+
+The pragmatic and business-friendly
+link:http://apache.org/licenses/LICENSE-2.0[Apache License] makes it easy
+for all users, commercial and individual, to deploy Apache products.
+
+link:http://www.apache.org/foundation/[Learn more about the ASF] as a whole,
+or engage with the link:https://community.apache.org/[Apache Community Development]
+project with your general questions about the ASF.

--- a/pages/index.ad
+++ b/pages/index.ad
@@ -18,7 +18,7 @@ The Incubator delegates a few mentors for each podling, as "on the
 ground" agents to act as liaisons with the various ASF teams:
 link:http://incubator.apache.org[Incubator PMC],
 link:https://selfserve.apache.org/[Infrastructure team], etc.,
-and facilitate the podling's growth and operations.
+and facilitates the podling's growth and operations.
 
 Our link:http://incubator.apache.org/cookbook/[cookbook] helps
 potential podlings decide whether the ASF is a good fit for them

--- a/pages/index.ad
+++ b/pages/index.ad
@@ -17,7 +17,7 @@ can become top-level ASF projets ("TLPs").
 The Incubator delegates a few mentors for each podling, as "on the
 ground" agents to act as liaisons with the various ASF teams:
 link:http://incubator.apache.org[Incubator PMC],
-link:https://selfserve.apache.org/[Infrastructure team] etc.
+link:https://selfserve.apache.org/[Infrastructure team], etc.,
 and facilitate the podling's growth and operations.
 
 Our link:http://incubator.apache.org/cookbook/[cookbook] helps

--- a/templates/menu.gsp
+++ b/templates/menu.gsp
@@ -31,6 +31,7 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Podling Guides <b class="caret"></b></a>
               <ul class="dropdown-menu">
+                <li><a href="/cookbook">Cookbook</a></li>
                 <%guides.each {guide -> %>
                   <li><a href="/${guide.uri}">${guide.title}</a></li>
                 <%}%>


### PR DESCRIPTION
I have reworked the homepage to express the Incubator's mission as providing services to podlings, as opposed to the current text which describes it more as a "stern gatekeeper to the ASF".

I'll ask for general agreement about this change on the general@ list and we can discuss details about the proposed text here if needed.