### PR TITLE
Adjust Incubator status URL

### DIFF
--- a/pages/policy/incubation.ad
+++ b/pages/policy/incubation.ad
@@ -133,7 +133,7 @@ product/project, please be aware that you will need to conduct a
 thorough licensing review to determine the overall implications of
 including this work. For the current status of this project through the Apache
 Incubator visit: 
-http://incubator.apache.org/project/[.underline]#Apache Podling-Name#.html
+https://incubator.apache.org/projects/[.underline]#Apache Podling-Name#.html
 ____
 
 For releases, the text SHOULD be included in a separate DISCLAIMER-WIP file


### PR DESCRIPTION
- Fix path to include 'projects' rather than 'project'
- Changed http to https (http works, but IMO preferring https when available is a good practice)