### PR TITLE
Fixed broken link for git repo requests

### DIFF
--- a/pages/guides/podling_sourcecontrol.ad
+++ b/pages/guides/podling_sourcecontrol.ad
@@ -26,7 +26,7 @@ git for source control.  For git, podlings may use repositories hosted at Apache
 
 === Set up GIT Repository
 
-Requests for new git repos are done via link:https://reporeq.apache.org/[reporeq.apache.org].
+Requests for new git repos are done via link:https://selfserve.apache.org/[selfserve.apache.org].
 This service will initialize a new repository, setup github mirrors and enable integrations for that repository.
 
 Historically, the Foundation's policy


### PR DESCRIPTION
Fixed broken link. Mail thread: https://lists.apache.org/thread.html/788265bca0e672e55efc0735fa54f871c85c65a5269857a33c5549b6@%3Cgeneral.incubator.apache.org%3E

cc @dave2wave 