### PR TITLE
Update ppmc.ad

### DIFF
--- a/pages/guides/ppmc.ad
+++ b/pages/guides/ppmc.ad
@@ -19,15 +19,15 @@ Apache Incubator PMC
 :imagesdir: ../images/
 
 == Podling Project Management Committee (PPMC)
-The Podling Project Management Committee (PPMC) helps a Podling learn how to govern itself. It works like a PMC but reports to the Incubator PMC instead of to the ASF Board.
+Each Podling Project Management Committee (PPMC) helps its Podling learn how to govern itself. It works like a PMC but reports to the Incubator PMC instead of to the ASF Board.
 Initially, it is composed of the Podling's mentors and the initial committers. The PPMC is directly responsible for the oversight of the podling, and it also decides who to add as a PPMC member.
 
 For general information about PMCs, see the link:http://www.apache.org/dev/pmc.html[PMC FAQ].
 
-== Private Mail List
+== Private Email List
 
-A private mail list, named private@*project*, lets the PPMC discuss confidential topics. *Most communication should be on the Podling's dev list!*
-The private list is used only for confidential discussions that should not be made public, such as the suitability of a particular individual to become a committer or a member of the PPMC. See the ASF *How it Works* section titled link:http://www.apache.org/foundation/how-it-works.html#confidential[Balancing confidentiality and public discussion].
+A private email list named private@*project* lets the PPMC discuss confidential topics. *Most communication should be on the Podling's dev list!*
+The private list is only for confidential discussions that should not be made public, such as the suitability of a particular individual to become a committer or a member of the PPMC. See the ASF *How it Works* section entitled link:http://www.apache.org/foundation/how-it-works.html#confidential[Balancing confidentiality and public discussion].
 
 The mentors should verify that all PPMC members are subscribed to the private list. The link:https://whimsy.apache.org/roster/ppmc/[Whimsy Podling Roster] shows who is subscribed, and any subscriber can send a "ping - please reply" message to check who is actually "listening" to the PPMC list.
 
@@ -37,15 +37,15 @@ The mentors should verify that all PPMC members are subscribed to the private li
 - Likewise, don't post to both the Incubator general and Incubator private lists. Each member of the Incubator PMC is on the Incubator general list, so posting to the general list is sufficient.
 
 == Podling Status Reports
-On a monthly basis, reports from each incubating project are collected and sent to the ASF Board. Watch the Incubator general mail list for when these become due.
+On a monthly basis, the IPMC collects reports from each incubating project and sends them to the ASF Board. Watch the Incubator general email list for when these become due.
 
-The Incubator report includes status for a subset of the incubating projects. Currently, new Podlings report to the Incubator monthly for the first three months, then quarterly after that.
+The Incubator report includes the status of a subset of the incubating projects. Currently, new Podlings report to the Incubator monthly for the first three months, then quarterly after that.
 
-The PPMC does not have to fill out the report itself; the PPMC is just responsible for making sure that it gets filled out. It is better to discuss the report on the dev list and ask everyone to contribute to it. If Mentors disagree with the posted report, they should say so; otherwise, the Incubator PMC will assume that it speaks for the community.
+The PPMC does not have to fill out the report itself; the PPMC is just responsible for making sure that it gets filled out. It is better to discuss the report on the dev list and ask everyone to contribute to it. If Mentors disagree with the posted report, they should say so; otherwise, the Incubator PMC assumes that the report speaks for the community.
 
-Please use the existing format and don't change the subjects. Note that the template is updated from time to time so be sure to use once provided and not a previous report.
+Please use the existing format and don't change the subject headers. Note that we update the template from time to time, so be sure to use the one we provide and not a previous report.
 
-Here are the points to be addressed:
+Here are the points to address:
 - Is there anything that the Incubator PMC or ASF Board specifically needs to address?
 - Are there any legal, infrastructure, cross-project or personal issues that need to be addressed?
 - Are there any stumbling blocks that impede the podling?
@@ -55,44 +55,44 @@ Here are the points to be addressed:
 - Are your mentors active and providing help?
 - etc. (your own thoughts on what is important would be helpful!)
 
-It is required for mentors to sign off on podling reports.
-- Mentors must sign off on the podling report. If there is no mentor sign off, the report from that podling will not be accepted, and they will be expected to report next month.
+Mentors must sign off on podling reports.
+- If there is no mentor sign off, the IPMC will not accept the report from that podling; it will have to submit a new report in the following month.
 
-Podling reports get added to the Incubator wiki:
-- All podling reports must be added to the link:https://cwiki.apache.org/confluence/display/INCUBATOR/Home[Incubator wiki]
+Add your podling reports to the Incubator wiki:
+- Add each podling report to the link:https://cwiki.apache.org/confluence/display/INCUBATOR/Home[Incubator wiki]
 - Follow the instructions in your report reminder, and post on the &lt;Month&gt;&lt;Year&gt; page, with the provided template
 
 == Project Status Page
-In addition to the quarterly status reports, each Podling has a page on the Incubator web site that tracks the status (see the link:http://incubator.apache.org/projects/index.html[complete list] for examples). Instructions for updating the status page are in the link:website.html[Incubator web site guide] under link:website.html#Edit+your+project+status+page[Edit your project status report].
+In addition to the quarterly status reports, each Podling has a page on the Incubator web site that tracks its status (see the link:http://incubator.apache.org/projects/index.html[complete list] for examples). Instructions for updating the status page are in the link:website.html[Incubator web site guide] under link:website.html#Edit+your+project+status+page[Edit your project status report].
 
-== Maintaining Podling Roster
-Podling rosters are maintained in link:https://whimsy.apache.org/roster/ppmc/[Whimsy Podling Roster]. Going forward, the content in *projects/$podling.xml* is considered deprecated.
+== Maintaining the Podling Roster
+Maintain your podling roster in link:https://whimsy.apache.org/roster/ppmc/[Whimsy Podling Roster]. Going forward, the content in *projects/$podling.xml* is deprecated.
 
-== Adding new committers
+== Adding committers
 
-Adding new committers is one of the most important functions of any PMC, and Incubator podlings are no different.
+Adding committers is one of the most important functions of any PMC, including Incubator podlings.
 
-There are no ASF wide rules on how to decide when to make someone a committer, podlings need to agree with an approach that works for them.
-Some ASF projects have a high bar requiring significant contributions before someone is considered, other projects grant it more freely to anyone who shows interest in contributing. Experience has shown that it's best to keep the bar low.
+There are no ASF-wide rules on how to decide when to invite someone to become a committer. Each podling needs to adopt an approach that works for it.
+Some ASF projects have a high bar requiring significant contributions before considering someone as a potential committer; other projects grant it more freely to anyone who shows interest in contributing. Experience shows that it's best to keep the bar low.
 
-Most projects use formal [DISCUSS] and [VOTE] threads on the private mailing list, and others use a more lazy consensus approach. For more information see, link:http://www.apache.org/foundation/glossary.html#CommitAccess[commit access] and the ASF *How it Works* document, which explains link:http://www.apache.org/foundation/how-it-works.html#meritocracy[ meritocracy] and link:http://www.apache.org/foundation/how-it-works.html#roles[ roles].
+Most projects use formal [DISCUSS] and [VOTE] threads on the private email list, and others use a more "lazy" consensus approach. For more information, see link:http://www.apache.org/foundation/glossary.html#CommitAccess[commit access] and the ASF *How it Works* document, which explains link:http://www.apache.org/foundation/how-it-works.html#meritocracy[meritocracy] and link:http://www.apache.org/foundation/how-it-works.html#roles[roles].
 
-The podling Incubator reports should document any new committers added since the last report.
+The podling Incubator reports should document any committers added since the previous report.
 
-Once the decision has been made, the podling offers committership to the nominee. If the nominee accepts the responsibility of being a committer for the project, the nominee formally becomes an Apache committer.
+If the podling decides in favor of the potential committer, it offers committership to the nominee. If the nominee accepts the responsibility of being a committer for the project, the nominee formally becomes an Apache committer.
 
-The proposer then asks an Incubator PMC member (typically one of the mentors) to follow the link:http://www.apache.org/dev/pmc.html#newcommitter[documentedprocedures] to complete the process. If the nominee is already an Apache committer on another project, the Incubator PMC member can add the nominee as a committer on the podling via the link:https://whimsy.apache.org/roster/ppmc/[Whimsy Podling Roster].
+The proposer then asks an IPMC member (typically one of the mentors) to follow the link:http://www.apache.org/dev/pmc.html#newcommitter[documentedprocedures] to complete the process. If the nominee is already an Apache committer on another project, the IPMC member can add the nominee as a committer on the podling via the link:https://whimsy.apache.org/roster/ppmc/[Whimsy Podling Roster].
 
-The proposer then directs the new committer to the link:http://www.apache.org/dev/[Apache developer's pages], to the link:http://incubator.apache.org/[Apache Incubator site] and the Incubator link:committer.html[Committers Guide] for important additional information.
+The proposer then directs the new committer to the link:http://www.apache.org/dev/[Apache developer's pages], to the link:http://incubator.apache.org/[Apache Incubator site] and to the Incubator link:committer.html[Committers Guide] for important additional information.
 
-For projects which wish to have all committers also be PPMC members, the "Voting in a new PPMC member" guide below should then be also followed. 
+Projects which wish to have all committers also be PPMC members should follow the "Voting in a new PPMC member" guide below. 
 
 == Voting in a new PPMC member
-It should be a goal of a podling to have all committers participate in the PPMC. The PPMC should take an active role in watching committers develop into community participants. They should identify those who are participating at a community level (not just a technical one), and approach them with an offer of PPMC membership.
+It should be a goal of a podling to have all committers participate in the PPMC. The PPMC should take an active role in watching committers develop as community participants. They should identify those who are participating at a community level (not just a technical one), and approach them with an offer of PPMC membership.
 
-Any member of the PPMC can propose a new member of the PPMC. The proposal should be discussed in private on the PPMC's private email list, with a subject line of "[DISCUSS] Joe Bob PPMC membership". If there is consensus that the proposed member is suitable, then there should be a formal vote with the subject line of "[VOTE] Joe Bob PPMC membership" on the PPMC's private email list.
+Any member of the PPMC can propose a new member of the PPMC. The proposal should be discussed in private on the PPMC's private email list, with a subject line of "[DISCUSS] Joe Bob PPMC membership". If there is consensus that the proposed member is suitable, there should be a formal vote with the subject line of "[VOTE] Joe Bob PPMC membership" on the PPMC's private email list.
 
-If the vote is successful,  a message should be sent to the PPMC private email list, with the subject line of "[VOTE][RESULT] Joe Bob PPMC membership".
+If the vote is successful, a member of the PPMC sends a message to the PPMC private email list, with the subject line of "[VOTE][RESULT] Joe Bob PPMC membership".
 The nominating PPMC member should send a message to the IPMC (link:mailto:private@incubator.apache.org[private@incubator.apache.org]) with a reference to the vote result in the following form:
 
 [source]
@@ -105,30 +105,30 @@ Body:
 Joe Bob has been voted as a new member of the *PODLING* PPMC. the vote thread is at: *link to the vote thread*
 --
 
-*Please note that there is a grace period of 72 hours from when the  NOTICE is sent to the Incubator PMC to when the proposed member should be formally invited. This is an important part of the overall process. Failure to do this can result in an embarassing situation for people involved.*
+*Note that there is a grace period of 72 hours from when the PPMC sends the  NOTICE to the IPMC to when the PPMC should formally invite the proposed member. This is an important part of the overall process. Failure to do this can result in an embarassing situation for people involved.*
 
 In the email you send, replace *PODLING* with your podling's actual name, and replace Joe Bob with the person's actual name.
 
-After 72 hours, Joe Bob should be invited to join the PPMC, using a sample message like link:ppmc-offer.txt[this].
+After 72 hours, the PPMC should invite Joe Bob to join it, using message like link:ppmc-offer.txt[this].
 
-Once the proposed member has accepted, a moderator for the PPMC mail list will accept the new member's subscription request.
+Once the proposed member has accepted, a moderator for the PPMC mail list accepts the new member's subscription request.
 
-The new member should be directed to link:ppmc.html[this page] for PPMC membership information.
+Direct the new member to link:ppmc.html[this page] for PPMC membership information.
 
-== Adding new mentors
+== Adding mentors
 
-At times, it may be desirable to add a new mentor to a podling. Under all circumstances, a mentor must be an IPMC member. People who are not IPMC members can still help out in an informal capacity.
+At times, it may be desirable to add a mentor to a podling. A mentor must be an IPMC member. People who are not IPMC members can still help out in an informal capacity.
 
-IPMC members are free to volunteer to be a mentor to a podling as they see fit. To do so, they should mail the podling stating their intentions. The podling should then decide if it wants to add the new mentor or not. If the Podling decides to add the mentor, then the mentor should be added to the link:https://whimsy.apache.org/roster/ppmc/[Whimsy Podling Roster].
+IPMC members are free to volunteer to mentor a podling. To do so, they should mail the podling stating their intentions. The podling should then decide whether it wants to add the mentor. If the Podling decides to add the mentor, it should do so in the link:https://whimsy.apache.org/roster/ppmc/[Whimsy Podling Roster].
 
-If a podling is in a position where they feel they need a new mentor, they can drop a mail on the general incubator mailing list to try to recruit a new mentor.
+If a podling is in a position where they feel they need a new mentor, they can drop an email on the general incubator email list to try to recruit a one.
 
 == Removing a mentor
 
-Occasionally it may be necessary to remove a mentor who has been too busy to participate or who has gone silent. After discussing it with the PPMC you can have someone with access (another mentor) remove them via link:https://whimsy.apache.org/roster/ppmc/[Whimsy].
+Occasionally it may be necessary to remove a mentor who has been too busy to participate or who has gone silent. After discussing it with the PPMC you can have someone with access (another mentor) remove the mentor via link:https://whimsy.apache.org/roster/ppmc/[Whimsy].
 
 == PPMC and Binding Votes
 
-The only time when a PPMC member's vote is binding is for the addition of new PPMC members and committers. Release votes are only binding to IPMC members.
+The only time when a PPMC member's vote is binding is for the addition of new PPMC members and committers. Release votes are only binding for IPMC members.
 
-The binding status of a person's vote is not related to the mailing list that the vote is occurring on.
+The binding status of a person's vote is not related to the email list that the vote occurs on.


### PR DESCRIPTION
Minor text edits.

Not sure that "Going forward, the content in *projects/$podling.xml* is deprecated." is still relevant or useful. When did the change happen?