### PR TITLE
Fix broken link

### DIFF
--- a/pages/cookbook/index.ad
+++ b/pages/cookbook/index.ad
@@ -13,7 +13,7 @@ It is *the* central point for all questions related to incubation. It provides a
 
 It is organized in chronological order of the steps that lead from incubating project acceptance to graduation as a Top-Level Project (TLP).
 
-We welcome feedback about the cookbook, either through the link:++https://lists.apache.org/list.html?general@incubator.apache.org++[general@incubator.a.o] email list
+We welcome feedback about the cookbook, either through the link:https://lists.apache.org/list.html?general@incubator.apache.org[general@incubator.a.o] email list
 or in the link:https://issues.apache.org/jira/browse/INCUBATOR-234[INCUBATOR-234] ticket. You can also submit patches to link:https://github.com/apache/incubator/tree/master/pages/cookbook[this repository].
 
 == Does our project fit the Apache Incubator?


### PR DESCRIPTION
Hope this is the right fix.  Right now, https://incubator.apache.org/cookbook/ displays wrong in the "Communicating with the Incubator" section:
```
To communicate with the Incubator PMC use the public
link:+https://lists.apache.org/list.html?general@incubator.apache.org [general@incubator.a.o]
mailing list. That page has links to subscribe to the list.
```
