### PR TITLE
chore: Send github notifications to cvs@i.a.o

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -5,3 +5,7 @@ github:
     - incubator
     - website
     - jbake
+
+notifications:
+  commits:      cvs@incubator.apache.org
+  pullrequests: cvs@incubator.apache.org


### PR DESCRIPTION
This pull request will modify the GitHub notifications to be sent to `cvs@i.a.o` instead of `general@i.a.o`.