### PR TITLE
Update ip_clearance.ad

### DIFF
--- a/pages/guides/ip_clearance.ad
+++ b/pages/guides/ip_clearance.ad
@@ -26,10 +26,10 @@ Podlings need to import existing codebases through the standard IP clearance
 process. This means that all copyright owners need to submit a Software Grant Agreement
 (link:http://www.apache.org/licenses/#grants[SGA])
 or Contributor License Agreement
-(link:http://www.apache.org/licenses/#clas[CLA]). This process may take a while so it is best to
+(link:http://www.apache.org/licenses/#clas[CLA]). This process may take a while, so it is best to
 start as soon as the Incubator accepts the podling.
 
-The IPMC (Incubator Product Management Committee) approves the initial codebase as part of the acceptance motion. So, no vote is required by the
+The IPMC (Incubator Product Management Committee) approves the initial codebase as part of the acceptance motion. No vote is required by the
 PPMC. Otherwise, follow the standard IP clearance process for podlings.
 
 === Establishing Provenance
@@ -60,8 +60,8 @@ No releases are possible until the podling has clearly established the provenanc
 therefore important to keep the status updated.
 
 The ASF Secretary records receipt of ICLAs, CCLAs, and SGAs in
-the private foundation repository. Reading is restricted to members and officers
-of the foundation. If there is no officer or member available to check whether the secretary has received all relevant documents, ask for help on the
+the private Foundation repository. Reading is restricted to members and officers
+of the Foundation. If there is no officer or member available to check whether the secretary has received all relevant documents, ask for help on the
 general list.
 
 === IPMC Responsibility around IP Clearance
@@ -70,7 +70,7 @@ The board has charged the Incubator project with management of IP clearance for 
 Instructions are link:http://incubator.apache.org/ip-clearance/index.html[here].
 
 These instructions also apply to podlings. The Incubator project is responsible for all podlings
-and so is the receiving PMC. So, when a podling requests IP clearance, the
+and so is the receiving PMC. When a podling requests IP clearance, the
 IPMC wears link:http://www.apache.org/foundation/how-it-works.html#hats[two hats].
 This may be a little confusing at first.
 
@@ -83,6 +83,8 @@ IP clearance for podlings. If too few binding VOTEs are posted on the list,
 the VOTE will need to be posted to the general list for ratification.
 
 The second hat is technical IP clearance. Here, the IPMC needs to check that the
-paperwork is in order. Once the IPMC approves the acceptance vote, an officer
+paperwork is in order. 
+
+Once the IPMC approves the acceptance vote, an officer
 or member need to complete the process. For a podling, this will typically
 involve a Mentor.


### PR DESCRIPTION
line 29: added a comma
lines 32 and 73: fixed grammar. It is not necessary to start a sentence with "So," if it logically follows the preceding sentence
lines 63-64: capitalized Foundation
line 88: paragraph break.