### PR TITLE
Update releasemanagement.ad

### DIFF
--- a/pages/guides/releasemanagement.ad
+++ b/pages/guides/releasemanagement.ad
@@ -23,12 +23,12 @@ Apache Incubator PMC
 
 One of the goals of incubation is to teach podling communities how to
 build ASF-compliant releases.  As part of the learning process, the podling community needs to be
-fully engaged in the review process.  A podling community should begin to familiarize themselves
+fully engaged in the release review process.  A podling community should begin to familiarize itself
 with the ASF policies for releases.  Those policies can be found at
 link:http://www.apache.org/dev/#releases[http://www.apache.org/dev/#releases].
 
 Releases are always produced by an Apache PMC, and for podlings, this PMC is the IPMC.  This is
-why it is mandatory to have at least 3 {plusone} votes from
+why it is mandatory to have at least 3 positive {plusone} votes from
 link:/incubation/roles_and_responsibilities.html#incubator_project_management_committee_ipmc[IPMC members].
 Usually, your link:/incubation/roles_and_responsibilities.html#mentor[mentors] (who are also IPMC members) will 
 vote on your releases, but if needed, other IPMC members will as well.  IPMC members will check for
@@ -70,7 +70,7 @@ services that the Apache Incubator offers our podling communities.
 
 == Podling Constraints
 
-The link:/incubation/Incubation_Policy.html#Releases[Incubator policies] applys two additional constraints 
+The link:/incubation/Incubation_Policy.html#Releases[Incubator policies] applies two additional constraints 
 to podlings for their releases.  They are repeated here for clarity only.
 - Release artifacts must include #incubating# in the final file name
 - Release artifacts must include one of two link:/guides/branding.html#disclaimers[disclaimers]
@@ -116,7 +116,7 @@ even if they are not compatible with the Apache license.
 Please carefully read this link:https://issues.apache.org/jira/browse/LEGAL-469[Legal JIRA] for more details on 
 what the IPMC and legal expectations are.
 
-By the time you graduate all issues listed in the disclaimer need to have been corrected,
+By the time you graduate, all issues listed in the disclaimer need to have been corrected,
 and you must use the standard disclaimer text.
 
 If a podling chooses uses the standards disclaimer, then the release must comply with all ASF policies.


### PR DESCRIPTION
line 26: Added a missing word. Changed 'themselves' to 'itself', referring to the PPMC. 
31: added a word to improve readability
73: fixed typo
119: added comma