### PR TITLE
Update publicity.ad

### DIFF
--- a/pages/guides/publicity.ad
+++ b/pages/guides/publicity.ad
@@ -9,7 +9,7 @@
 //WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //See the License for the specific language governing permissions and
 //limitations under the License.
-= Podling Publicity/Media Guidelines
+= Podling Publicity/Media
 Apache Incubator PMC
 2002-10-16
 :jbake-type: guide
@@ -20,9 +20,16 @@ Apache Incubator PMC
 
 Requirements for all podlings relating to publicity in general.
 
+Table of Contents
+1) Prior to Entering the Apache Incubator
+2) During the Incubation Process
+3) Preparing to Graduate
+    PPMC Responsibilities For Announcements
+
+
 == 1) Prior to Entering the Apache Incubator
 
-Under no circumstances may any individuals or organizations seek publicity related to the proposed podling during this process. Per the Incubator Branding Guidelines, you may not refer to a podling as "Apache _Podling Name_" until the Apache Incubator has officially accepted, its mailing lists are active, and podling participants have submtited code related to the podling into Apache repositories. 
+Under no circumstances may any individuals or organizations seek publicity related to the proposed podling during this process. Per the https://incubator.apache.org/guides/branding.html[Incubator Branding Guidelines], you may not refer to a podling as "Apache _Podling Name_" until the Apache Incubator has officially accepted, its mailing lists are active, and podling participants have submtited code related to the podling into Apache repositories. 
 
 No party can make announcements or statements 1) about their intention to submit a named project to the Apache Incubator or 2) that a specific project has been submitted to the Apache Incubator.
 
@@ -31,9 +38,9 @@ You may not disseminate formal press releases or announcements of any kind on an
 
 == 2) During the Incubation Process
 
-We encourage Apache podlings and their communities to actively build awareness of their project through emails, blog posts, tweets, and other means of outreach. Educational opportunities include online meetings, videos, podcasts, articles, and interactions at conferences and related community events.
+We encourage Apache podlings and their communities to actively build awareness of their project through emails, blog posts, social media, and other means of outreach. Educational opportunities include online meetings, videos, podcasts, articles, and interactions at conferences and related community events.
 
-When speaking with members of the media and analyst community, you must refer to the podling as "Apache _Podling Name_" as per the Branding Guidelines, along with explaining the requisite podling disclaimer(s). Be prepared to answer "who uses you?". As a podling’s known user base grows, PMCs (Project Management Committees) are welcome to promote their users in a "Powered By" page such as https://cwiki.apache.org/hadoop/PoweredBy[Apache Hadoop's Powered By page]. Create and promote podling users to https://incubator.apache.org/guides/press-kit.html[display the "Powered By" logo]. Also, ensure that the podling maintains http://apache.org/press/media.html#interviews[*vendor neutrality*], particularly when referring to project users.
+When speaking with members of the media and analyst community, you must refer to the podling as "Apache _Podling Name_" as per the Branding Guidelines, along with explaining the requisite podling disclaimer(s). Be prepared to answer "Who uses you?" As a podling’s known user base grows, PMCs (Project Management Committees) are welcome to promote their users on a "Powered By" page such as https://cwiki.apache.org/hadoop/PoweredBy[Apache Hadoop's Powered By page]. Create and promote podling users to https://incubator.apache.org/guides/press-kit.html[display the "Powered By" logo]. Also, ensure that the podling maintains http://apache.org/press/media.html#interviews[*vendor neutrality*], particularly when referring to project users.
 
 Podlings should prepare news announcements and hone their messaging _privately_ within their PMCs (keeping the content confidential to the PMC, and not on dev@, user@ or any other public list or forum) to ensure that the public or press don’t scoop your story before it’s out or publish inaccurate information. Messaging may change, features may not be available as soon as intended, testimonials may need adjusting, and so on, and it’s best to minimize the chances of your story getting out with incorrect information, or for nobody to cover your news story because it was covered earlier and is therefore no longer considered newsworthy.
 
@@ -41,37 +48,36 @@ We strenuously recommend that podlings refrain from issuing announcements under 
 
 As all Apache PMCs (and Incubator PPMCs) are responsible for the "care and feeding" of a project’s code, community, and communications on a day-to-day basis, we recommend that Podlings:
 
-- Ensure your [project listing and DOAP (Description Of A Project) file](https://projects.apache.org/) accurately reflect what the podling is about. Be succinct, particularly with the short description (note that the project may fall under one category): this helps those unfamiliar with your project find you. Use the longer project description as the official project boilerplate ("About Apache _Project Name_") and, for consistency, include it in official news announcements, media briefings, and other publications (the ASF Boilerplate is for Foundation-originating press releases and is **not** to be used in any project announcements).
-- Upload a high-resolution version of your project’s logo at [apache.org/logos/](http://www.apache.org/logos/).
+- Ensure your https://projects.apache.org/[project listing and DOAP (Description Of A Project) file] accurately reflects what the podling is about. Be succinct, particularly with the short description (note that the project may fall under one category): this helps those unfamiliar with your project find you. Use the longer project description as the official project boilerplate ("About Apache _Project Name_") and, for consistency, include it in official news announcements, media briefings, and other publications (the ASF Boilerplate is for Foundation-originating press releases and is **not** to be used in any project announcements).
+- Upload a high-resolution version of your project’s logo at http://www.apache.org/logos/[apache.org/logos/].
 - Contact ASF Infrastructure to establish a https://blogs.apache.org/_PROJECTNAME_ project blog directory (and admin/publishing credentials).
-- Request a project interview on [Feathercast, the voice of the ASF](https://feathercast.apache.org/).
-- Gain additional exposure by posting newsworthy podling updates and milestones to [announce(at)apache(dot)org](http://apache.org/foundation/mailinglists.html#foundation-announce). The Apache team adds these to the Apache Weekly News Round-Ups, which it also sends to members of the media and analyst community.
-- Establish a Twitter (and/or other social media) account(s) with a handle that includes "Apache" or "ASF" with the project name and description (example at [https://twitter.com/ApacheAccumulo](https://twitter.com/ApacheAccumulo) ). Share information often, and point to your podling Website and email list archives where possible. 
+- Request a project interview on https://feathercast.apache.org/[Feathercast, the voice of the ASF].
+- Gain additional exposure by posting newsworthy podling updates and milestones to http://apache.org/foundation/mailinglists.html#foundation-announce[announce(at)apache(dot)org]. The Apache team adds these to the Apache Weekly News Round-Ups, which it also sends to members of the media and analyst community.
+- Establish a Twitter (and/or other social media) account(s) with a handle that includes "Apache" or "ASF" with the project name and description (example at https://twitter.com/ApacheAccumulo[https://twitter.com/ApacheAccumulo]). Share information often, and point to your podling Website and email list archives where possible. 
 - Participate in Media & Analyst Training (held during ApacheCon; complimentary for Apache Committers and Members).
 - Comply with guidelines for "founding" individuals, organizations, and communities of Apache podlings as applicable (details below).
 
-Podling cannot disseminate formal press releases or announcements of any kind on any newswire service during the Incubation process. Furthermore, cannot encourage, allow, or particiapte in any announcement by a third party on behalf of a podling undergoing development in the Apache Incubator. However, interested parties may issue supporting announcements with pointers to official podling-originating news, providing the announcement includes a link to the corresponding mailing list(s) and/or blog post.
-
+Podling cannot disseminate formal press releases or announcements of any kind on any newswire service during the Incubation process. Furthermore, cannot encourage, allow, or participate in any announcement by a third party on behalf of a podling undergoing development in the Apache Incubator. However, interested parties may issue supporting announcements with pointers to official podling-originating news, providing the announcement includes a link to the corresponding mailing list(s) and/or blog post.
 
 == 3) Preparing to Graduate
 
-Podlings wishing to issue a press release announcing their graduation as an Apache Top-Level Project (TLP) must contact ASF Marketing & Publicity at least two weeks before submitting the graduation resolution to the ASF Board in order to provide sufficient preparation time.
+Podlings wishing to issue a press release announcing their graduation as an Apache Top-Level Project (TLP) must follow ASF Marketing & Publicity (ASF M&P) https://docs.google.com/document/d/1y3fZYn92LlnNadYxUsRiJEMwz0urKxnotBtDn0Cq_G0/edit[guidelines].
 
-Podling Project Management Committees (PPMCs) work together with ASF Marketing & Publicity to issue a formal ASF press release, which is also a great opportunity to solicit quotes/testimonials from the Podling’s community to demonstrate the project's robustness and breadth of deployment.
+Podling Project Management Committees (PPMCs) are responsible for writing the first draft of a formal ASF press release and sharing it with ASF M&P for approval. A press release is a great opportunity to solicit quotes/testimonials from the Podling’s community to demonstrate the project’s robustness and breadth of deployment. TLP announcements may include 1-2 quotes (including, but not limited to, VP of the project/PMC chair and community endorsements). A recent example of a TLP press release is: https://news.apache.org/foundation/entry/the-apache-software-foundation-announces-new-top-level-project-apache-seatunnel[The Apache Software Foundation Announces New Top Level Project Apache SeaTunnel™].
 
-TLP announcements have ranged from having single quotes (VP of the project/PMC chair) to several perspectives from the PMC to multiple endorsements from the community. A great example press release is: https://blogs.apache.org/foundation/date/20180110[The Apache Software Foundation Announces Apache® Trafodion™ as a Top-Level Project].
-
-Organizations supporting/using the Podling are welcome to issue their own, standalone "hurrah, Apache _Podling Name_!" press release (or blog post) to support the podling's graduation. All third parties need to coordinate messaging and timing with both the Podling PMC and ASF Marketing & Publicity. Third party releases must not use Apache boilerplate.
+Organizations supporting/using the Podling are welcome to issue their own, standalone "hurrah, Apache Podling Name!" press release (or blog post) to support the Podling’s graduation after the ASF has issued its announcement. All third parties need to coordinate messaging and timing with both the Podling PMC and ASF M&P. Third-party releases must not use the Apache boilerplate.
 
 === PPMC Responsibilities For Announcements
 
 - Determine the primary point-of-contact during the drafting/editing process.
 
-- Help draft the announcement (primarily "what is Podling Name"/features+functionality).
-
 - Determine whether to include supporting testimonials from the community (and solicit them).
 
-- Work with ASF Marketing & Publicity to ensure the announcement timing is in sync (preferable to roll out announcements within a 24-48 hour timeframe, rather than announce the project's graduation on the project’s dev@/user@ lists or on announce@apache.org, followed by a press release several weeks later).
+- Draft the announcement by following these steps: https://docs.google.com/document/d/1y3fZYn92LlnNadYxUsRiJEMwz0urKxnotBtDn0Cq_G0/edit[TLP Press Release & Distro Process + Guidelines]
+
+- Send your complete draft to press(at)apache(dot)org for review and indicate if/when your project was approved as a TLP by the ASF Board. The ASF Marketing & Publicity team will work with you to edit, finalize, and distribute your release. Once final, ASF M&P will post it on a newswire, the ASF blog, and ASF social media channels.
+
+- Coordinate any promotion timing closely with M&P, including announcing the project’s graduation on any mailing lists.
 
 Note that some organizations require legal clearance to participate in any media activities, and may require several weeks to obtain sign-off on proposed participation in the form of testimonials or being listed as a corporate user.
 


### PR DESCRIPTION
Updated content on the Incubator Publicity page approved by @bproffitt, ASF VP Marketing & Publicity to help clarify the process (as well as fixing links that were displaying markdown code vs hyperlinking as intended).

Brian, to you for final review.
