### PR TITLE
Drop the incubator- prefix for GitHub Repos

### DIFF
--- a/pages/guides/distribution.ad
+++ b/pages/guides/distribution.ad
@@ -58,13 +58,13 @@ To comply with ASF release and distributions, please ensure the following:
 Additional guidelines and process for releasing Maven components can be found link:https://infra.apache.org/publishing-maven-artifacts.html[on this infra page].
 
 == GitHub
-Artifacts show up on **https://github.com/apache/incubator-<project>/releases**.
+Artifacts show up on **https://github.com/apache/<project>/releases**.
 To comply with ASF release and distributions please ensure the following:
 
 * Any releases need to include the text of the incubation disclaimer.
 * The release page must not contain release candidates, nightly or snapshots releases that have not been tagged as prereleases. (Ignoring that GitHub also displays tags on the release page.)
-* Any releases that exist before coming into incubation need to be clearly described on the release page and tagged as such on **https://github.com/apache/incubator-<project>/tags**.
-* Release candidates, nightlys or snapshots releases can be tagged and appear on **https://github.com/apache/incubator-<project>/tags**.
+* Any releases that exist before coming into incubation need to be clearly described on the release page and tagged as such on **https://github.com/apache/<project>/tags**.
+* Release candidates, nightlys or snapshots releases can be tagged and appear on **https://github.com/apache/<project>/tags**.
 
 == Docker
 Artifacts need to be placed in **https://hub.docker.com/r/apache/<project>** or **https://hub.docker.com/u/apache<project>/<project>**.

--- a/pages/guides/lists.ad
+++ b/pages/guides/lists.ad
@@ -30,7 +30,6 @@ Please read the link:http://www.apache.org/foundation/public-archives.html[Apach
 This email list is where general and public discussions related to the Incubator take place.
 - link:mailto:general-subscribe@incubator.apache.org[Subscribe]
 - link:mailto:general-unsubscribe@incubator.apache.org[Unsubscribe]
-- link:http://mail-archives.apache.org/mod_mbox/incubator-general/[Archives]
 - link:https://lists.apache.org/list.html?general@incubator.apache.org[Searchable Archives]
 
 You can also use link:https://whimsy.apache.org/committers/subscribe[Whimsy] to manage your subscriptions if you are a committer at Apache.
@@ -43,7 +42,6 @@ this list. Replies go to the link:general+at+incubator.apache.org[general list].
 
 - link:mailto:cvs-subscribe@incubator.apache.org[Subscribe]
 - link:mailto:cvs-unsubscribe@incubator.apache.org[Unsubscribe]
-- link:http://mail-archives.apache.org/mod_mbox/incubator-cvs/[Archives]
 - link:https://lists.apache.org/list.html?cvs@incubator.apache.org[Searchable Archives]
 
 === podlings at incubator.apache.org

--- a/pages/guides/names.ad
+++ b/pages/guides/names.ad
@@ -28,7 +28,7 @@ reducing the legal resources required and
 limiting the potential disruption to a community of a forced name change 
 later. A smooth path, but not the only one. If there are reasons
 why this road isn't right for your podling, 
-consult link:http://mail-archives.apache.org/mod_mbox/incubator-general/[incubator general].
+consult link:https://lists.apache.org/list.html?general@incubator.apache.org[incubator general].
 
 === Meet the Apache Branding Team
 
@@ -170,7 +170,7 @@ and progress less smooth.
 We describe the main sequence here. This well-known path is
 appropriate for almost all podlings.
 If there are good reasons to think that your podling is a special case, discuss this with the
-link:http://mail-archives.apache.org/mod_mbox/incubator-general/[Incubator community]
+link:https://lists.apache.org/list.html?general@incubator.apache.org[Incubator community]
 and reach consensus on the way forward.
 
 ==== Appropriateness
@@ -221,7 +221,7 @@ reasons for eliminating a name. This is an example of a condition with a fractal
 boundary. You do not need to eliminate as unsuitable every name which has been used before,
 but this is an issue which you need to discuss more widely so you can reach
 a consensus with the broad 
-link:http://mail-archives.apache.org/mod_mbox/incubator-general/[Incubator community]. 
+link:https://lists.apache.org/list.html?general@incubator.apache.org[Incubator community]. 
 
 Look for evidence of existing adoption amongst open source communities by searching well-known
 foundries (for example link:http://www.github.com[GitHub] and 

--- a/pages/guides/transferring.ad
+++ b/pages/guides/transferring.ad
@@ -148,8 +148,6 @@ forms the final public record for
 graduation.
 
 - Source
-** Git repositories will be renamed to drop the `incubator-` prefix, please ensure that developers change their remotes.
-After you've created the TLP request, request the rename.
 ** SVN repositories will be moved from the incubator to other locations, if you need the move done please raise an infra ticket after the TLP Parent Request.
 ** Post an announcement to the development list telling everyone that the repository is about to be moved
 ** Post an announcement containing instructions for developers describing how to #svn switch# their workspaces


### PR DESCRIPTION
According to the vote and related discussion - https://lists.apache.org/thread/1kf8spl8z8m91773yqzxbhx27mrhxhdg