### PR TITLE
Fix minor errors in documentation

### DIFF
--- a/pages/index.ad
+++ b/pages/index.ad
@@ -42,5 +42,5 @@ The Foundation provides an established framework for intellectual property and f
 
 Through a collaborative and meritocratic development process known as "link:http://apache.org/theapacheway/[the Apache Way]," Apache projects deliver enterprise-grade, freely available software products that attract large communities of users.
 
-The pragmatic and business-friendly link:http://apache.org/licenses/LICENSE-2.0[Apache License] makes it easy for all users, commercial and individual, to deploy Apache products. link:http://www.apache.org/foundation/[Learn more about the ASF] as a whole, or engage with the link:https://community.apache.org/[Apache Community Development] project with your general questions about the ASF.
+The pragmatic and business-friendly link:http://apache.org/licenses/LICENSE-2.0[Apache License] makes deploying Apache products easier for all users, both commercial and individual. link:http://www.apache.org/foundation/[Learn more about the ASF] as a whole, or engage with the link:https://community.apache.org/[Apache Community Development] project with your general questions about the ASF.
 

--- a/pages/index.ad
+++ b/pages/index.ad
@@ -40,7 +40,7 @@ The Apache Software Foundation provides organizational, legal, and financial sup
 
 The Foundation provides an established framework for intellectual property and financial contributions that simultaneously limits potential legal exposure for the contributors.
 
-Through a collaborative and meritocratic development process known as "link:http://apache.org/theapacheway/[the Apache Way]," Apache projects deliver enterprise-grade, freely-available software products that attract large communities of users.
+Through a collaborative and meritocratic development process known as "link:http://apache.org/theapacheway/[the Apache Way]," Apache projects deliver enterprise-grade, freely available software products that attract large communities of users.
 
 The pragmatic and business-friendly link:http://apache.org/licenses/LICENSE-2.0[Apache License] makes it easy for all users, commercial and individual, to deploy Apache products. link:http://www.apache.org/foundation/[Learn more about the ASF] as a whole, or engage with the link:https://community.apache.org/[Apache Community Development] project with your general questions about the ASF.
 

--- a/pages/index.ad
+++ b/pages/index.ad
@@ -40,7 +40,7 @@ The Apache Software Foundation provides organizational, legal, and financial sup
 
 The Foundation provides an established framework for intellectual property and financial contributions that simultaneously limits potential legal exposure for the contributors.
 
-Through a collaborative and meritocratic development process known as "link:http://apache.org/theapacheway/[the Apache Way]", Apache projects deliver enterprise-grade, freely-available software products that attract large communities of users.
+Through a collaborative and meritocratic development process known as "link:http://apache.org/theapacheway/[the Apache Way]," Apache projects deliver enterprise-grade, freely-available software products that attract large communities of users.
 
 The pragmatic and business-friendly link:http://apache.org/licenses/LICENSE-2.0[Apache License] makes it easy for all users, commercial and individual, to deploy Apache products. link:http://www.apache.org/foundation/[Learn more about the ASF] as a whole, or engage with the link:https://community.apache.org/[Apache Community Development] project with your general questions about the ASF.
 

--- a/pages/policy/incubation.ad
+++ b/pages/policy/incubation.ad
@@ -21,7 +21,7 @@ link:https://www.apache.org/foundation/records/minutes/2002/board_minutes_2002_1
        board **the promotion of such products to independent PMC
        status** once their community has reached maturity.
 
-See the October 2002 link:https://www.apache.org/foundation/board/calendar-1999-2004.html#2002 [Board report] for the resolution.
+See the October 2002 link:https://www.apache.org/foundation/board/calendar-1999-2004.html#2002[Board report] for the resolution.
 
 The Incubator has the following responsibilities:
 


### PR DESCRIPTION
This pull request suggests a few small changes to correct minor errors in Incubator documentation. In particular, it suggests:

- Moving a comma inside quotation marks to ensure consistency
- Removing an unnecessary hyphen
- Re-writing a sentence to aid readability
- Correcting syntax for formatting a hyperlink

This is my first contribution to an Apache project.