### PR TITLE
docs: improve website accessibility and HTTPS consistency

### DIFF
--- a/pages/index.ad
+++ b/pages/index.ad
@@ -8,7 +8,7 @@ Apache Incubator PMC
 
 The Apache Incubator provides services to projects seeking to enter the Apache Software Foundation (ASF).
 
-It helps those incoming projects (called "podlings") adopt the Apache link:http://apache.org/theapacheway/[style of governance and operation], and it guides them to services and resources they can use to become top-level ASF projects ("TLPs").
+It helps those incoming projects (called "podlings") adopt the Apache link:https://www.apache.org/theapacheway/[style of governance and operation], and it guides them to services and resources they can use to become top-level ASF projects ("TLPs").
 
 The Incubator delegates mentors to each podling. Mentors act as liaisons between podlings and various ASF teams, such as the link:http://incubator.apache.org/whoweare.html#the_incubator_project_management_commitee_pmc[Incubator PMC] and the link:https://selfserve.apache.org/[Infrastructure team], to facilitate podlings' operations and ongoing growth.
 
@@ -27,7 +27,7 @@ The Incubator has the following responsibilities:
 To get started with the Apache Incubator:
 
 - Read the link:/cookbook[cookbook], which helps potential podlings decide whether the ASF is a good fit for them and guides them through the steps required to become an ASF podling.
-- Review the link:/policy/incubation.html[Incubation Policy], which outlines rules for participation
+- Review the link:/policy/incubation.html[Incubation Policy], which outlines rules for participation.
 - Submit a link:/guides/proposal.html[proposal] for your project to join the Incubator
 
 == Useful Resources
@@ -36,13 +36,13 @@ For advice on applying to—and ultimately graduating from—Apache Incubator, r
 - A keynote on link:https://www.youtube.com/watch?v=TQwrH0PlpZg[The Apache Way] by Rich Bowen at MesosCon Europe in 2017, which offers insights into both the ASF's values and its operations.
 - link:https://www.youtube.com/watch?v=I0-lp1t9ee0["How to get your release through the Incubator"], presented at ApacheCon North America 2017, for guidance on releases.
 - A more general talk on link:https://www.youtube.com/watch?v=hpAv54KIgK8[Effective open source management] by Shane Curcuru, from ApacheCon North America 2017.
-- John D. Ament's link:https://www.youtube.com/watch?v=yWurOHvm5WM["Navigating the Incubator Trenches"], from ApacheCon North America 2017, for details on how to graduate from the Incubator and become a successful TLP
+- John D. Ament's link:https://www.youtube.com/watch?v=yWurOHvm5WM["Navigating the Incubator Trenches"], from ApacheCon North America 2017, for details on how to graduate from the Incubator and become a successful TLP.
 - link:https://www.youtube.com/watch?v=SCDv2hUgOjU["Apache Incubator: the gateway into the Apache Way"] by Roman Shaposhnik and Suresh Marru at ApacheCon North America 2014.
-- link:http://www.youtube.com/watch?v=KopPbWS87fw["Life In The Apache Incubator"], in which former Incubator PMC chair Jukka Zitting presents the Incubator, from ApacheCon Europe 2012.
+- link:https://www.youtube.com/watch?v=KopPbWS87fw["Life In The Apache Incubator"], in which former Incubator PMC chair Jukka Zitting presents the Incubator, from ApacheCon Europe 2012.
 
 == Incubator History
 
-In October 2002, the Board of Directors of the Apache Software Foundation passed a resolution to establish the Apache Incubator PMC. It directed the ASF to: 
+In October 2002, the Board of Directors of the Apache Software Foundation passed a resolution to establish the Apache Incubator PMC. It directed the ASF to:
 
 [quote, ASF Board Meeting, October 16th 2002]
 ...establish a Project Management Committee charged with
@@ -64,7 +64,6 @@ The Apache Software Foundation provides organizational, legal, and financial sup
 
 The Foundation provides an established framework for intellectual property and financial contributions that simultaneously limits potential legal exposure for the contributors.
 
-Through a collaborative and meritocratic development process known as "link:http://apache.org/theapacheway/[the Apache Way]," Apache projects deliver enterprise-grade, freely available software products that attract large communities of users.
+Through a collaborative and meritocratic development process known as "link:https://www.apache.org/theapacheway/[the Apache Way]," Apache projects deliver enterprise-grade, freely available software products that attract large communities of users.
 
 The pragmatic and business-friendly link:http://apache.org/licenses/LICENSE-2.0[Apache License] makes deploying Apache products easier for all users, both commercial and individual. link:http://www.apache.org/foundation/[Learn more about the ASF] as a whole, or engage with the link:https://community.apache.org/[Apache Community Development] project with your general questions about the ASF.
-


### PR DESCRIPTION
This PR improves the Apache Incubator website documentation with small accessibility and consistency fixes:

- Standardize "The Apache Way" links to HTTPS URLs (changed 2 instances from http to https)
- Add missing period to "Getting Started" section for consistent punctuation
- Minor text improvements for better readability

These are minimal, non-breaking changes that improve security and consistency.
